### PR TITLE
Add domain model diagram using mermaid

### DIFF
--- a/profile/srap-profile.md
+++ b/profile/srap-profile.md
@@ -46,7 +46,22 @@ Degree supervisor is a person under whose supervision a degree candidate develop
 
 Opponent is a person responsible for opposing a thesis or dissertation. 
 
-Figure 1. SRAP domain model (to be added).
+Figure 1. SRAP domain model.
+
+```mermaid
+classDiagram
+direction LR
+class SR["Scholarly Resource"]
+class Dataset
+class AA["Affiliated Agent"]
+Agent <|-- AA
+class Agent
+class Organization
+SR --> Dataset : related dataset
+SR --> Agent : creator\neditor\nfunder\ndegree supervisor\nopponent
+AA --> Organization : affiliation
+AA --> Agent : agent
+```
 
 ## Alphabetic table of elements
 

--- a/profile/srap-profile.md
+++ b/profile/srap-profile.md
@@ -53,14 +53,15 @@ classDiagram
 direction LR
 class SR["Scholarly Resource"]
 class Dataset
-class AA["Affiliated Agent"]
-Agent <|-- AA
-class Agent
+class AP["Affiliated Person"]
+Person <|-- AP
+class Person
 class Organization
 SR --> Dataset : related dataset
-SR --> Agent : creator\neditor\nfunder\ndegree supervisor\nopponent
-AA --> Organization : affiliation
-AA --> Agent : agent
+SR --> Person : creator\neditor\ndegree supervisor\nopponent
+SR --> Organization : creator\nfunder
+AP --> Organization : affiliation
+AP --> Person : person
 ```
 
 ## Alphabetic table of elements


### PR DESCRIPTION
The current SRAP spec has no domain model diagram, so I decided to create one. Instead of using an external editing tool, I decided to try out Mermaid which can nowadays be used [directly from Markdown documents on GitHub](https://github.blog/2022-02-14-include-diagrams-markdown-files-mermaid/).

The diagram is based on https://github.com/dcmi/dc-srap/issues/3#issuecomment-1128838415 and includes the modeling of Affiliated Agents.

The layout is not ideal but the cool thing about Mermaid is that the diagram is defined just as text, so it's pretty easy to edit. We will need to adjust this anyway to be able to represent enumeration information (#28). 

To see how this looks in the document open [this link](https://github.com/dcmi/dc-srap/blob/612820936505993ea5cd329fa2d4d16f2835b9dc/profile/srap-profile.md).