### PR TITLE
Add properties for volume, issue, pageStart, pageEnd and document how to use them

### DIFF
--- a/docs/examples/journalArticle.md
+++ b/docs/examples/journalArticle.md
@@ -34,8 +34,8 @@ dct:identifier <https://doi.org/10.1016/j.cpcardiol.2020.100618> .
 _:B
 a bibo:Journal ;
 dct:title "Current problems in cardiology" ;
-bibo:issn <urn:issn:0146-2806> ;
-bibo:eissn <urn:issn:1535-6280> .
+bibo:issn "0146-2806" ;
+bibo:eissn "1535-6280" .
 ```
 ## Visualization
 

--- a/docs/examples/journalArticle.md
+++ b/docs/examples/journalArticle.md
@@ -41,8 +41,7 @@ bibo:eissn "1535-6280" .
 
 Created from the above Turtle data using [RDF Sketch](https://sketch.zazuko.com/)
 
-![image](https://github.com/dcmi/dc-srap/assets/1132830/42cbd09b-bb3b-4633-9b4e-893cad7c166f)
-
+![image](https://github.com/dcmi/dc-srap/assets/1132830/55c99e29-7666-47a2-9d3f-fbadc44e2952)
 
 ## Flat version
 

--- a/docs/srap-profile.md
+++ b/docs/srap-profile.md
@@ -84,6 +84,10 @@ Using uncontrolled (local) contributor roles reduces semantic interoperability a
 * Sponsor
 * Translator
 
+## Volume, issue and page numbers
+
+A scholarly article may be published in a journal or other periodical that uses numbered volumes and issues as well as page numbers.  These should be represented using the BIBO properties `bibo:volume`, `bibo:issue`, `bibo:pageStart` and `bibo:pageEnd`. The relationship between the article and the journal should be represented using the `dct:isPartOf` relationship. See the [journal article example](examples/journalArticle.md) for more details.
+
 ## Generic elements 
 
 ### Access Rights  

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -23,7 +23,7 @@ Scholarly Resource,Abstract,dct:abstract,xsd:string,,,,Free text
 ,*Grant number,,xsd:string,,,,"An alpha-numeric string identifying the contract, project or funding grant under which the scholarly resource was created."
 ,Has Part,dct:hasPart,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
 ,Identifier,dct:identifier,xsd:anyURI xsd:string,,,,"URI, one for each identifier the resource has, provided separately"
-,Is Part Of,dct:isPartOf,xsd:anyURI xsd:string,,,,A related resource that this resource is part of.
+,Is Part Of,dct:isPartOf,xsd:anyURI xsd:string,Periodical,,,A related resource that this resource is part of.
 ,Is Referenced By,dct:isReferencedBy,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
 ,Is Version Of,dct:isVersionOf,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
 ,Issued,dct:issued,xsd:date,,,,Date according to ISO 8601-1
@@ -47,16 +47,16 @@ Scholarly Resource,Abstract,dct:abstract,xsd:string,,,,Free text
 ,Degree committee member,marcrel:dgc ,xsd:anyURI,Person,,,"A person who is part of a committee that considers the merit of a thesis, dissertation, or other submission by an academic degree candidate."
 ,Degree granting institution,marcrel:dgg ,xsd:anyURI,Organization,,,Name and identifier of an organization 
 ,Degree supervisor ,marcrel:dgs ,xsd:anyURI,Person,,,An organization granting an academic degree.
-,Dissertant,marcrel:dis ,xsd:anyURI,Person,,,"A person who presents a thesis for a university or higher-level educational degree."
+,Dissertant,marcrel:dis ,xsd:anyURI,Person,,,A person who presents a thesis for a university or higher-level educational degree.
 ,Opponent,marcrel:opn ,xsd:anyURI,Person,,,A person or organization responsible for opposing a thesis or dissertation.
 ,Praeses ,marcrel:pra ,xsd:anyURI,Person,,,"A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation."
-,Respondent,marcrel:rsp ,xsd:anyURI,Person,,,"A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation."
+,Respondent,marcrel:rsp ,xsd:anyURI,Person,,,A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation.
 ,Thesis advisor,marcrel:ths ,xsd:anyURI,Person,,,"A person under whose supervision a degree candidate develops and presents a thesis, memoire, or text of a dissertation."
 ,Abridger ,marcrel:abr ,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged"
 ,Compiler ,marcrel:com ,xsd:anyURI,Person Organization,,,"A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc."
 ,Editor ,marcrel:edt ,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author."
 ,Editor of compilation ,marcrel:edc ,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler."
-,Funder ,marcrel:fnd ,xsd:anyURI,Person Organization,,,"A person or organization that furnished financial support for the production of the work."
+,Funder ,marcrel:fnd ,xsd:anyURI,Person Organization,,,A person or organization that furnished financial support for the production of the work.
 ,Honoree ,marcrel:hnr ,xsd:anyURI,Person Organization,,,"A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)"
 ,Host institution ,marcrel:his ,xsd:anyURI,Organization,,,"An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource."
 ,Organizer ,marcrel:orm ,xsd:anyURI,Person Organization,,,"A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource."
@@ -69,7 +69,8 @@ Scholarly Resource,Abstract,dct:abstract,xsd:string,,,,Free text
 ,Start page,bibo:pageStart,xsd:string,,,,Starting page number within a continuous page range.
 ,End page,bibo:pageEnd,xsd:string,,,,Ending page number within a continuous page range.
 ,,,,,,,
-Periodical,Title,dct:title,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
+Periodical,Class,rdf:type,xsd:anyURI,,bibo:Periodical,,Class (always bibo:Periodical or one of its subclasses)
+,Title,dct:title,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
 ,ISSN,bibo:issn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for the printed version of serial publications."
 ,E-ISSN,bibo:eissn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for electronic versions of serial publications."
 ,,,,,,,

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -23,7 +23,7 @@ Scholarly Resource,Abstract,dct:abstract,xsd:string,,,,Free text
 ,*Grant number,,xsd:string,,,,"An alpha-numeric string identifying the contract, project or funding grant under which the scholarly resource was created."
 ,Has Part,dct:hasPart,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
 ,Identifier,dct:identifier,xsd:anyURI xsd:string,,,,"URI, one for each identifier the resource has, provided separately"
-,Is Part Of,dct:isPartOf,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
+,Is Part Of,dct:isPartOf,xsd:anyURI xsd:string,,,,A related resource that this resource is part of.
 ,Is Referenced By,dct:isReferencedBy,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
 ,Is Version Of,dct:isVersionOf,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
 ,Issued,dct:issued,xsd:date,,,,Date according to ISO 8601-1
@@ -64,7 +64,14 @@ Scholarly Resource,Abstract,dct:abstract,xsd:string,,,,Free text
 ,Reviser ,,xsd:anyURI,Person,,,Name and identifier of a person
 ,Sponsor ,marcrel:spn ,xsd:anyURI,Person Organization,,,"A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event."
 ,Translator ,marcrel:trl ,xsd:anyURI,Person Organization,,,"A person or organization who renders a text from one language into another, or from an older form of a language into the modern form."
+,Volume,bibo:volume,xsd:string,,,,A volume number of the periodical where this article was published
+,Issue,bibo:issue,xsd:string,,,,An issue number of the periodical that this article was published in
+,Start page,bibo:pageStart,xsd:string,,,,Starting page number within a continuous page range.
+,End page,bibo:pageEnd,xsd:string,,,,Ending page number within a continuous page range.
 ,,,,,,,
+Periodical,Title,dct:title,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
+,ISSN,bibo:issn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for the printed version of serial publications."
+,E-ISSN,bibo:eissn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for electronic versions of serial publications."
 ,,,,,,,
 Person,Affiliation,dct:affiliation,,Organization,,,"An organization to which an agent was affiliated when the resource was created. Recommended practice is to identify the affiliation with a URI. If this is not possible or feasible, a literal value that identifies the affiliated organization may be provided. It is also possible to give both the name and the URI. If a name is given, it should be provided in full and in hierarchical order, starting from the largest organizational unit. NOTE This element should not be used to provide the current (at the time the metadata is created) affiliation of the agent, or all affiliations the agent has had over time."
 ,Name,foaf:Name,xsd:string,,,,Name of person

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -69,7 +69,7 @@ Scholarly Resource,Abstract,dct:abstract,xsd:string,,,,Free text
 ,Start page,bibo:pageStart,xsd:string,,,,Starting page number within a continuous page range.
 ,End page,bibo:pageEnd,xsd:string,,,,Ending page number within a continuous page range.
 ,,,,,,,
-Periodical,Class,rdf:type,xsd:anyURI,,bibo:Periodical,,Class (always bibo:Periodical or one of its subclasses)
+Periodical,Class,rdf:type,xsd:anyURI,,bibo:Periodical bibo:Journal,,Class (always bibo:Periodical or one of its subclasses)
 ,Title,dct:title,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
 ,ISSN,bibo:issn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for the printed version of serial publications."
 ,E-ISSN,bibo:eissn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for electronic versions of serial publications."


### PR DESCRIPTION
This PR adds the BIBO properties volume, issue, pageStart, pageEnd and documentation how to use them.

Fixes the ISSN example to use plain literals instead of URNs, following the BIBO property definitions (BIBO defines `issn` and `eissn` with the range Literal).

Closes #28