### PR TITLE
Restructure the DCTAP

### DIFF
--- a/docs/srap-profile.md
+++ b/docs/srap-profile.md
@@ -10,7 +10,7 @@ There is significant overlap between SRAP, UKOLN SWAP, the Finnish guidelines, a
 
 The SRAP application profile proposal is intended to be globally applicable. All suggested properties were “battle-proven”, in use. There are new properties for e.g. creator and contributor roles, but these have been adopted from MARC 21. SRAP draft contains also recommendations for SRAP-related semantic refinements to some existing Dublin Core Terms properties, in order to make them more suitable for use in the description of scholarly resources.  
 
-Roles of contributors are based on Library of Congress Relator terms and their associated codes[^6] or other controlled contributor lists. Contributor roles presented below are examples of ones that can be used.  
+Roles of contributors are based on [Library of Congress Relator terms](https://www.loc.gov/marc/relators/relaterm.html) or other controlled contributor lists. Contributor roles presented below are examples of ones that can be used.
 
 Note 1: All new DCMI Metadata Terms URIs are just suggestions until this profile has been approved, and marked with asterisk (*). 
 
@@ -58,16 +58,7 @@ SRAP makes it possible to express the status of a scholarly in a publishing work
 
 ### Publication Status (srap:publicationStatus)
 
-The stage of the resource in the publishing workflow.
-
-Recommended practice is to use a publication status value from the following list, ordered according to the increasing level of maturity:
-
-* public draft
-* preprint
-* postprint
-* submitted manuscript
-* publication
-* updated publication
+The stage of the resource in the publishing workflow. Recommended practice is to use a publication status value from the [OpenAIRE Publication Version vocabulary](https://guidelines.openaire.eu/en/latest/literature/field_publicationversion.html).
 
 NOTE: Publication status should be used when there are several versions of the same resource, and publication status can be used for telling them apart. Status information should be accompanied with an appropriate date specification whenever such date can be obtained from the resource itself or metadata linked to it.
 
@@ -125,7 +116,7 @@ NOTE Date available covers all resource types and news embargo, a request by a s
 
 Subproperty of: Date (dct:date)
 
-Date when the final version of the resource was made available in the Web or in print format before publication in a journal issue.
+Date when the final version of the resource was made available on the Web or in print format before publication in a journal issue.
 
 NOTE Many scientific journals operate article-level publishing, whereby articles are processed for publication immediately following acceptance. Such articles are later compiled into the next journal issue to be published. Recommended practice is to use Date ahead of print to record the date when the article was published, and Date published to record the date when the journal issue was published.  
 
@@ -260,7 +251,7 @@ Recommended practice is to refer to a rights statement with a URI. If this is no
 
 NOTE: Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights.
 
-### Rights Holder (srap:rightsHolder)
+### Rights Holder (dct:rightsHolder)
 
 A person or organization owning or managing rights over the resource.
 
@@ -334,7 +325,7 @@ Subproperty of: References (dct:references)
 
 ## Roles 
 
-Creators and contributors of scholarly resources may have a wide variety of roles. SRAP does not provide a comprehensive role list; recommended practice is to use the Library of Congress MARC Relator codes or some other controlled list to express roles such as the [RDA Unconstrained](https://www.rdaregistry.info/Elements/u/) properties. See below for examples of existing roles that may be used with thesis or with scientific articles. Lists are not mutually exclusive; for instance, a thesis may have a translator. 
+Creators and contributors of scholarly resources may have a wide variety of roles. SRAP does not provide a comprehensive role list; recommended practice is to use the [Library of Congress MARC Relator codes](https://www.loc.gov/marc/relators/relaterm.html) or some other controlled list to express roles such as the [RDA Unconstrained](https://www.rdaregistry.info/Elements/u/) properties. See below for examples of existing roles that may be used with thesis or with scientific articles. Lists are not mutually exclusive; for instance, a thesis may have a translator.
 
 Using uncontrolled (local) contributor roles reduces semantic interoperability and should be avoided. 
 

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -1,83 +1,89 @@
-shapeID,propertyLabel,propertyID,valueDatatype,valueShape,valueConstraint,valueConstraintType,note
-,,,,,,,
-Scholarly Resource,Abstract,dct:abstract,xsd:string,,,,Free text
-,Access rights,dct:accessRights,xsd:anyURI,,http://vocabularies.coar-repositories.org/documentation/access_rights/,IRIstem,A term from COAR vocabulary (http://vocabularies.coar-repositories.org/documentation/access_rights/
-,*Accessibility statement,,xsd:string,,,,"Textual information describing the accessibility features of a resource, including technical details. Recommended practice is to define the accessibility options, such as software requirements for using the document or technical features such as open or closed captioning."
-,Bibliographic citation,dct:bibliographicCitation,xsd:string,,,,A bibliographic reference for the resource. Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible.
-,Contributor,dct:contributor,,Person,,,
-,Creator,dct:creator,,Person,,,Name and identifier of persons and/or organizations
-,Date,dct:date,xsd:date,,,,Date according to ISO 8601-1
-,Date accepted,dct:dateAccepted,xsd:date,,,,Date of acceptance of the resource. Recommended practice is to provide this date if it is specified in the resource. Examples of scholarly resources to which a date of acceptance may be relevant are a thesis (accepted by a university department) or a scientific article (accepted by a journal).
-,*Date ahead of print,,xsd:date,,,,"Date when the final version of the resource was made available in the Web or in print format before publication in a journal issue. NOTE Many scientific journals operate article-level publishing, whereby articles are processed for publication immediately following acceptance. Such articles are later compiled into the next journal issue to be published. Recommended practice is to use Date ahead of print to record the date when the article was published, and Date published to record the date when the journal issue was published."
-,*Date available as public draft,,xsd:date,,,,Date when an early draft of the resource (predating even preprint) has been made available in an open repository such as ArXiv.
-,*Date missing,,xsd:date,,,,"Date when the resource went missing. Recommended practice is to provide this date only if there is no reasonable doubt that the resource is missing; that is, there may be one or more copies left but they cannot be found. Criteria for making the decision that the resource is missing may be developed locally. A SRAP record with date missing should have sufficient metadata to serve as a temporary tombstone of the resource. Date missing may be used when e.g. a printed copy (item) of a resource has disappeared and its current location is unknown for the time being."
-,*Date lost,,xsd:date,,,,"Date when the resource was lost. Recommended practice is to provide this date only if there is no reasonable doubt that the resource has been lost; that is, there is not a single (readable) copy of it left. Criteria for making the decision that the resource has been lost may be developed locally, but can include for instance digital documents that can no longer be rendered. A SRAP record with date lost should contain sufficient metadata to serve as a permanent tombstone of the resource. Date lost should be used when e.g. the only known copy of a digital or printed resource has been destroyed or otherwise rendered unusable. Date lost should not be used when a publisher fails but its resources (e.g. serials) are still preserved in a legal deposit collection. Rights metadata should be updated to reflect changes in restrictions on access and use of such archived resources. For serials and other continuing publications, the most convenient solution is to provide this metadata in the host record, from which it may be copied to all component part (article) records."
-,*Date received as manuscript,,xsd:date,,,,Date when the resource is first received by the publisher. Recommended practice is to provide this data when it is indicated in the resource.
-,*Date retracted,,xsd:date,,,,Date when the resource was retracted or withdrawn. Recommended practice is to provide the reason for retraction or withdrawal in the Description element. NOTE: Do not use Date lost or Date missing for retracted resources.
-,Date submitted,dct:dateSubmitted,xsd:date,,,,Date according to ISO 8601-1
-,*Date submitted as preprint,,xsd:date,,,,"Date when an author submits a preprint of an unpublished resource to a repository. Recommended practice is to provide this information when it is included in the resource, provided by the author or available in the repository application."
-,*Date updated,,xsd:date,,,,Date(s) when the publication was republished with additional or revised content. Recommended practice is to provide this date if it is specified in the publication.
-,Description,dct:description,xsd:string,,,,Free text; different languages shall be provided separately (as different Description elements)
-,*Embargo date range,,xsd:date,,,,"A period of time during which the resource is under embargo. Recommended practice is to describe the date range as recommended for the property Date. NOTE Date available covers all resource types and news embargo, a request by a source that the information or news provided by that source not be published until a certain date or certain conditions have been met."
-,Format,dct:format,xsd:string,,,,MIME type registered by IANA
-,*Grant number,,xsd:string,,,,"An alpha-numeric string identifying the contract, project or funding grant under which the scholarly resource was created."
-,Has Part,dct:hasPart,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
-,Identifier,dct:identifier,xsd:anyURI xsd:string,,,,"URI, one for each identifier the resource has, provided separately"
-,Is Part Of,dct:isPartOf,xsd:anyURI xsd:string,Periodical,,,A related resource that this resource is part of.
-,Is Referenced By,dct:isReferencedBy,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
-,Is Version Of,dct:isVersionOf,xsd:anyURI xsd:string,,,,URI or other identifier of the related resource
-,Issued,dct:issued,xsd:date,,,,Date according to ISO 8601-1
-,Language,dct:language,xsd:string,,,,"A code from ISO 639-2, one for each language used in the resource, provided separately"
-,License,dct:license,xsd:anyURI xsd:string,,,,"A legal document giving official permission to do something with the resource. Recommended practice is to identify the license document with a URI. If this is not possible or feasible, a literal value that identifies the license may be provided."
-,Modified,dct:modified,xsd:date,,,,Date according to ISO 8601-1
-,Presented at,bibo:presentedAt,xsd:anyURI xsd:string,,,,"Conference, workshop or other scientific event where the scholarly resource was presented. Recommended practice is to identify formal meetings such as conferences with a URI. If this is not possible or feasible, a literal value that identifies the meeting may be provided. It is also possible to give both the name and the URI."
-,*Publication status,,xsd:anyURI,,info:eu-repo/semantics/,IRIstem,"The stage of the resource in the publishing workflow. Recommended practice is to use a publication status value from the following list, ordered according to the increasing level of maturity: / public draft / preprint / postprint / submitted manuscript / publication / updated publication. NOTE: Publication status should be used when there are several versions of the same resource, and publication status can be used for telling them apart. Status information should be accompanied with an appropriate date specification whenever such date can be obtained from the resource itself or metadata linked to it. OpenAire publication status code from https://guidelines.openaire.eu/en/latest/literature/field_publicationversion.html"
-,Publisher,dct:publisher,,Organization,,,Name and URI of the organization
-,*Related code,,xsd:anyURI,,,,Code (software applications) referenced in the resource. Recommended practice is to identify the code with a URI identifying either the code or a landing page through which the application or applications are accessed.
-,*Related dataset,,xsd:anyURI,,,,Dataset or datasets referenced in the described scholarly resource. Recommended practice is to identify a dataset with a URI identifying either the dataset or a landing page through which the dataset is accessed.
-,Relation,dct:relation,xsd:anyURI xsd:string,,,,"A related resorce. Recommended practice is to identify the related resource by means of a URI. If this is not possible or feasible, a string conforming to a formal identification system may be provided."
-,Rights,dct:rights,xsd:anyURI xsd:string,,,,"Information about rights held in and over the resource. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided."
-,Rights Holder,dct:rightsHolder,xsd:anyURI xsd:string,,,,"A person or organization owning or managing rights over the resource. Recommended practice is to refer to the rights holder with a URI. If this is not possible or feasible, a literal value that identifies the rights holder may be provided."
-,Subject,dct:subject,xsd:anyURI xsd:string,,,,A concept from a controlled vocabulary such as LCSH or MeSH
-,Table of Contents,dct:tableOfContents,xsd:string,,,,A list of subunits of the resource.
-,Title,dct:title,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
-,Type,dct:type,xsd:anyURI,,http://purl.org/coar/resource_type,IRIstem,"A term from COAR resource type vocabulary, http://purl.org/coar/resource_type"
-,Academic supervisor,,,,,,Thesis role 
-,Dedicatee ,marcrel:dte ,xsd:anyURI,Person Organization,,,"A person, family, or organization to whom a resource is dedicated. "
-,Degree committee member,marcrel:dgc ,xsd:anyURI,Person,,,"A person who is part of a committee that considers the merit of a thesis, dissertation, or other submission by an academic degree candidate."
-,Degree granting institution,marcrel:dgg ,xsd:anyURI,Organization,,,Name and identifier of an organization 
-,Degree supervisor ,marcrel:dgs ,xsd:anyURI,Person,,,An organization granting an academic degree.
-,Dissertant,marcrel:dis ,xsd:anyURI,Person,,,A person who presents a thesis for a university or higher-level educational degree.
-,Opponent,marcrel:opn ,xsd:anyURI,Person,,,A person or organization responsible for opposing a thesis or dissertation.
-,Praeses ,marcrel:pra ,xsd:anyURI,Person,,,"A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation."
-,Respondent,marcrel:rsp ,xsd:anyURI,Person,,,A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation.
-,Thesis advisor,marcrel:ths ,xsd:anyURI,Person,,,"A person under whose supervision a degree candidate develops and presents a thesis, memoire, or text of a dissertation."
-,Abridger ,marcrel:abr ,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged"
-,Compiler ,marcrel:com ,xsd:anyURI,Person Organization,,,"A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc."
-,Editor ,marcrel:edt ,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author."
-,Editor of compilation ,marcrel:edc ,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler."
-,Funder ,marcrel:fnd ,xsd:anyURI,Person Organization,,,A person or organization that furnished financial support for the production of the work.
-,Honoree ,marcrel:hnr ,xsd:anyURI,Person Organization,,,"A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)"
-,Host institution ,marcrel:his ,xsd:anyURI,Organization,,,"An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource."
-,Organizer ,marcrel:orm ,xsd:anyURI,Person Organization,,,"A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource."
-,Reviewer ,marcrel:rev ,xsd:anyURI,Person Organization,,,"A person or organization responsible for the review of a book, motion picture, performance, etc."
-,Reviser ,,xsd:anyURI,Person,,,Name and identifier of a person
-,Sponsor ,marcrel:spn ,xsd:anyURI,Person Organization,,,"A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event."
-,Translator ,marcrel:trl ,xsd:anyURI,Person Organization,,,"A person or organization who renders a text from one language into another, or from an older form of a language into the modern form."
-,Volume,bibo:volume,xsd:string,,,,A volume number of the periodical where this article was published
-,Issue,bibo:issue,xsd:string,,,,An issue number of the periodical that this article was published in
-,Start page,bibo:pageStart,xsd:string,,,,Starting page number within a continuous page range.
-,End page,bibo:pageEnd,xsd:string,,,,Ending page number within a continuous page range.
-,,,,,,,
-Periodical,Class,rdf:type,xsd:anyURI,,bibo:Periodical bibo:Journal,,Class (always bibo:Periodical or one of its subclasses)
-,Title,dct:title,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
-,ISSN,bibo:issn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for the printed version of serial publications."
-,E-ISSN,bibo:eissn,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for electronic versions of serial publications."
-,,,,,,,
-Person,Affiliation,dct:affiliation,,Organization,,,"An organization to which an agent was affiliated when the resource was created. Recommended practice is to identify the affiliation with a URI. If this is not possible or feasible, a literal value that identifies the affiliated organization may be provided. It is also possible to give both the name and the URI. If a name is given, it should be provided in full and in hierarchical order, starting from the largest organizational unit. NOTE This element should not be used to provide the current (at the time the metadata is created) affiliation of the agent, or all affiliations the agent has had over time."
-,Name,foaf:Name,xsd:string,,,,Name of person
-,Identifier,dct:identifier,xsd:anyURI xsd:string,,,,"Identifier for the person, such as ORCID"
-,,,,,,,
-,,,,,,,
-Organization,Identifier,dct:identifier,xsd:anyURI xsd:string,,,,Identifier for the organization
-,Name,foaf:name,xsd:string,,,,Name of the organization
+shapeID,propertyLabel,propertyID,valueNodeType,valueDatatype,valueShape,valueConstraint,valueConstraintType,note
+,,,,,,,,
+Scholarly Resource,Type,dct:type,IRI,xsd:anyURI,,http://purl.org/coar/resource_type/,IRIstem,"Resource type, using the COAR Resorce Types vocabulary."
+,Description,dct:description,literal,xsd:string,,,,An account of the resource.
+,Abstract,dct:abstract,literal,xsd:string,,,,A summary of the resource.
+,Contributor,dct:contributor,IRI,xsd:anyURI,Person,,,An entity responsible for making contributions to the resource.
+,Creator,dct:creator,IRI,xsd:anyURI,Person,,,An entity responsible for making the resource.
+,Language,dct:language,literal,xsd:string,,,,A language of the resource.
+,Publisher,dct:publisher,IRI,xsd:anyURI,Organization,,,An entity responsible for making the resource available.
+,Subject,dct:subject,IRI literal,xsd:anyURI xsd:string,,,,The topic of the resource; a concept from a controlled vocabulary such as LCSH or MeSH
+,Title,dct:title,literal,xsd:string,,,,A name given to the resource.
+,Relation,dct:relation,IRI literal,xsd:anyURI xsd:string,,,,A related resorce.
+,Format,dct:format,literal,xsd:string,,,,"The file format, physical medium, or dimensions of the resource."
+,Table of Contents,dct:tableOfContents,literal,xsd:string,,,,A list of subunits of the resource.
+,,,,,,,,
+,Publication Status,srap:publicationStatus,IRI,xsd:anyURI,,info:eu-repo/semantics/,IRIstem,"The stage of the resource in the publishing workflow, using the OpenAIRE Publication Version vocabulary."
+,Date Issued,dct:issued,literal,xsd:date,,,,Date of formal issuance of the resource.
+,Date Modified,dct:modified,literal,xsd:date,,,,Date on which the resource was changed.
+,Date Accepted,dct:dateAccepted,literal,xsd:date,,,,Date of acceptance of the resource.
+,Date Lost,srap:dateLost,literal,xsd:date,,,,Date when the resource was lost.
+,Date Missing,srap:dateMissing,literal,xsd:date,,,,Date when the resource went missing.
+,Embargo Date Range,srap:embargoDateRange,literal,xsd:date,,,,A period of time during which the resource is under embargo.
+,Date Ahead of Print,srap:dateAheadOfPrint,literal,xsd:date,,,,Date when the final version of the resource was made available on the Web or in print format before publication in a journal issue.
+,Date Available as Public Draft,srap:dateAvailableAsPublicDraft,literal,xsd:date,,,,Date when an early draft of the resource (predating even preprint) has been made available in an open repository such as ArXiv.
+,Date Received as Manuscript,srap:dateReceivedAsManuscript,literal,xsd:date,,,,Date when the resource is first received by the publisher.
+,Date Retracted,fabio:hasRetractionDate,literal,xsd:date,,,,Date when the resource was retracted or withdrawn.
+,Date Submitted as Preprint,srap:dateSubmittedAsPreprint,literal,xsd:date,,,,Date when an author submits a preprint of an unpublished resource to a repository.
+,Date Submitted as Postprint,srap:dateSubmittedAsPostprint,literal,xsd:date,,,,Date when an author submits a postprint of an unpublished resource to a repository.
+,Date Updated,srap:dateUpdated,literal,xsd:date,,,,Date(s) when the publication was republished with additional or revised content.
+,,,,,,,,
+,Volume,bibo:volume,literal,xsd:string,,,,A volume number of the periodical where this article was published
+,Issue,bibo:issue,literal,xsd:string,,,,An issue number of the periodical that this article was published in
+,Start page,bibo:pageStart,literal,xsd:string,,,,Starting page number within a continuous page range.
+,End page,bibo:pageEnd,literal,xsd:string,,,,Ending page number within a continuous page range.
+,Is Part Of,dct:isPartOf,IRI literal,xsd:anyURI xsd:string,Periodical,,,A related resource in which the described resource is physically or logically included.
+,Has Part,dct:hasPart,IRI literal,xsd:anyURI xsd:string,,,,A related resource that is included either physically or logically in the described resource.
+,Presented At,bibo:presentedAt,IRI literal,xsd:anyURI xsd:string,,,,"Conference, workshop or other scientific event where the scholarly resource was presented."
+,Bibliographic Citation,dct:bibliographicCitation,literal,xsd:string,,,,A bibliographic reference for the resource.
+,,,,,,,,
+,Access Rights,dct:accessRights,IRI,xsd:anyURI,,http://purl.org/coar/access_right/,IRIstem,"Access status of the resource, using the COAR Access Rights vocabulary."
+,License,dct:license,IRI literal,xsd:anyURI xsd:string,,,,A legal document giving official permission to do something with the resource.
+,Rights,dct:rights,IRI literal,xsd:anyURI xsd:string,,,,Information about rights held in and over the resource.
+,Rights Holder,dct:rightsHolder,IRI literal,xsd:anyURI xsd:string,,,,A person or organization owning or managing rights over the resource.
+,,,,,,,,
+,Accessibility statement,srap:accessibilityStatement,literal,xsd:string,,,,"Textual information describing the accessibility features of a resource, including technical details."
+,,,,,,,,
+,Grant number,srap:grantNumber,literal,xsd:string,,,,"An alpha-numeric string identifying the contract, project or funding grant under which the scholarly resource was created."
+,,,,,,,,
+,Identifier,dct:identifier,IRI literal,xsd:anyURI xsd:string,,,,"URI, one for each identifier the resource has, provided separately"
+,ISBN,bibo:isbn,literal,xsd:string,,,,The International Standard Book Number of the resource.
+,,,,,,,,
+,Related code,srap:relatedCode,IRI,xsd:anyURI,,,,Code (software applications) referenced in the resource.
+,Related dataset,srap:relatedDataset,IRI,xsd:anyURI,,,,Dataset or datasets referenced in the described resource.
+,,,,,,,,
+,Academic supervisor,rdau:P61096,IRI,xsd:anyURI,Person,,,"Relates a resource to an agent who is responsible for overseeing academic activity of any kind that results in a resource, including theses, research, and projects."
+,Dedicatee ,marcrel:dte ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization to whom a resource is dedicated. "
+,Degree committee member,marcrel:dgc ,IRI,xsd:anyURI,Person,,,"A person who is part of a committee that considers the merit of a thesis, dissertation, or other submission by an academic degree candidate."
+,Degree granting institution,marcrel:dgg ,IRI,xsd:anyURI,Organization,,,A organization granting an academic degree.
+,Degree supervisor ,marcrel:dgs ,IRI,xsd:anyURI,Person,,,A person overseeing a higher level academic degree.
+,Dissertant,marcrel:dis ,IRI,xsd:anyURI,Person,,,A person who presents a thesis for a university or higher-level educational degree.
+,Opponent,marcrel:opn ,IRI,xsd:anyURI,Person,,,A person or organization responsible for opposing a thesis or dissertation.
+,Praeses ,marcrel:pra ,IRI,xsd:anyURI,Person,,,"A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation."
+,Respondent,marcrel:rsp ,IRI,xsd:anyURI,Person,,,A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation.
+,Thesis advisor,marcrel:ths ,IRI,xsd:anyURI,Person,,,"A person under whose supervision a degree candidate develops and presents a thesis, memoire, or text of a dissertation."
+,,,,,,,,
+,Abridger ,marcrel:abr ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged"
+,Compiler ,marcrel:com ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc."
+,Editor ,marcrel:edt ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author."
+,Editor of compilation ,marcrel:edc ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler."
+,Funder ,marcrel:fnd ,IRI,xsd:anyURI,Person Organization,,,A person or organization that furnished financial support for the production of the work.
+,Honoree ,marcrel:hnr ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)"
+,Host institution ,marcrel:his ,IRI,xsd:anyURI,Organization,,,"An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource."
+,Organizer ,marcrel:orm ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource."
+,Reviewer ,marcrel:rev ,IRI,xsd:anyURI,Person Organization,,,"A person or organization responsible for the review of a book, motion picture, performance, etc."
+,Reviser ,rdau:P60245,IRI,xsd:anyURI,Person,,,Relates an agent to a resource that includes a contribution by an agent of making changes to the content.
+,Sponsor ,marcrel:spn ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event."
+,Translator ,marcrel:trl ,IRI,xsd:anyURI,Person Organization,,,"A person or organization who renders a text from one language into another, or from an older form of a language into the modern form."
+,,,,,,,,
+Periodical,Class,rdf:type,IRI,xsd:anyURI,,bibo:Periodical bibo:Journal,,Class (always bibo:Periodical or one of its subclasses)
+,Title,dct:title,literal,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
+,ISSN,bibo:issn,literal,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for the printed version of serial publications."
+,E-ISSN,bibo:eissn,literal,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for electronic versions of serial publications."
+,,,,,,,,
+Person,Affiliation,schema:affiliation,,,Organization,,,"An organization to which an agent was affiliated when the resource was created. Recommended practice is to identify the affiliation with a URI. If this is not possible or feasible, a literal value that identifies the affiliated organization may be provided. It is also possible to give both the name and the URI. If a name is given, it should be provided in full and in hierarchical order, starting from the largest organizational unit. NOTE This element should not be used to provide the current (at the time the metadata is created) affiliation of the agent, or all affiliations the agent has had over time."
+,Name,foaf:Name,literal,xsd:string,,,,Name of person
+,Identifier,dct:identifier,IRI literal,xsd:anyURI xsd:string,,,,"Identifier for the person, such as ORCID"
+,,,,,,,,
+Organization,Identifier,dct:identifier,IRI literal,xsd:anyURI xsd:string,,,,Identifier for the organization
+,Name,foaf:name,literal,xsd:string,,,,Name of the organization

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -81,7 +81,7 @@ Book,Class,rdf:type,IRI,,,bibo:Book,,
 ,Date,dct:date,Literal,xsd:string,,,,
 ,,,,,,,,
 Person,Class,rdf:type,IRI,,,foaf:Person,,
-,Affiliation,schema:affiliation,,,Organization,,,"An organization to which an agent was affiliated when the resource was created. Recommended practice is to identify the affiliation with a URI. If this is not possible or feasible, a literal value that identifies the affiliated organization may be provided. It is also possible to give both the name and the URI. If a name is given, it should be provided in full and in hierarchical order, starting from the largest organizational unit. NOTE This element should not be used to provide the current (at the time the metadata is created) affiliation of the agent, or all affiliations the agent has had over time."
+,Affiliation,schema:affiliation,,,Organization,,,An organization to which an agent was affiliated when the resource was created.
 ,Name,foaf:Name,literal,xsd:string,,,,Name of person
 ,Identifier,dct:identifier,IRI literal,,,,,"Identifier for the person, such as ORCID"
 ,,,,,,,,

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -1,89 +1,90 @@
 shapeID,propertyLabel,propertyID,valueNodeType,valueDatatype,valueShape,valueConstraint,valueConstraintType,note
 ,,,,,,,,
-Scholarly Resource,Type,dct:type,IRI,xsd:anyURI,,http://purl.org/coar/resource_type/,IRIstem,"Resource type, using the COAR Resorce Types vocabulary."
-,Description,dct:description,literal,xsd:string,,,,An account of the resource.
-,Abstract,dct:abstract,literal,xsd:string,,,,A summary of the resource.
-,Contributor,dct:contributor,IRI,xsd:anyURI,Person,,,An entity responsible for making contributions to the resource.
-,Creator,dct:creator,IRI,xsd:anyURI,Person,,,An entity responsible for making the resource.
+Scholarly Resource,Type,dct:type,IRI,,,http://purl.org/coar/resource_type/,IRIstem,"Resource type, using the COAR Resorce Types vocabulary."
+,Contributor,dct:contributor,IRI,,Person,,,An entity responsible for making contributions to the resource.
+,Creator,dct:creator,IRI,,Person,,,An entity responsible for making the resource.
 ,Language,dct:language,literal,xsd:string,,,,A language of the resource.
-,Publisher,dct:publisher,IRI,xsd:anyURI,Organization,,,An entity responsible for making the resource available.
-,Subject,dct:subject,IRI literal,xsd:anyURI xsd:string,,,,The topic of the resource; a concept from a controlled vocabulary such as LCSH or MeSH
-,Title,dct:title,literal,xsd:string,,,,A name given to the resource.
-,Relation,dct:relation,IRI literal,xsd:anyURI xsd:string,,,,A related resorce.
-,Format,dct:format,literal,xsd:string,,,,"The file format, physical medium, or dimensions of the resource."
-,Table of Contents,dct:tableOfContents,literal,xsd:string,,,,A list of subunits of the resource.
+,Publisher,dct:publisher,IRI,,Organization,,,An entity responsible for making the resource available.
+,Subject,dct:subject,IRI literal,,,,,The topic of the resource; a concept from a controlled vocabulary such as LCSH or MeSH
+,Title,dct:title,literal,,,,,A name given to the resource.
+,Format,dct:format,literal,,,,,"The file format, physical medium, or dimensions of the resource."
 ,,,,,,,,
-,Publication Status,srap:publicationStatus,IRI,xsd:anyURI,,info:eu-repo/semantics/,IRIstem,"The stage of the resource in the publishing workflow, using the OpenAIRE Publication Version vocabulary."
+,Publication Status,srap:publicationStatus,IRI,,,info:eu-repo/semantics/,IRIstem,"The stage of the resource in the publishing workflow, using the OpenAIRE Publication Version vocabulary."
+,Date published,dct:date,Literal,xsd:date,,,,Date associated with the resource. Use more specific dates if available.s
 ,Date Issued,dct:issued,literal,xsd:date,,,,Date of formal issuance of the resource.
 ,Date Modified,dct:modified,literal,xsd:date,,,,Date on which the resource was changed.
 ,Date Accepted,dct:dateAccepted,literal,xsd:date,,,,Date of acceptance of the resource.
-,Date Lost,srap:dateLost,literal,xsd:date,,,,Date when the resource was lost.
-,Date Missing,srap:dateMissing,literal,xsd:date,,,,Date when the resource went missing.
 ,Embargo Date Range,srap:embargoDateRange,literal,xsd:date,,,,A period of time during which the resource is under embargo.
-,Date Ahead of Print,srap:dateAheadOfPrint,literal,xsd:date,,,,Date when the final version of the resource was made available on the Web or in print format before publication in a journal issue.
-,Date Available as Public Draft,srap:dateAvailableAsPublicDraft,literal,xsd:date,,,,Date when an early draft of the resource (predating even preprint) has been made available in an open repository such as ArXiv.
-,Date Received as Manuscript,srap:dateReceivedAsManuscript,literal,xsd:date,,,,Date when the resource is first received by the publisher.
 ,Date Retracted,fabio:hasRetractionDate,literal,xsd:date,,,,Date when the resource was retracted or withdrawn.
-,Date Submitted as Preprint,srap:dateSubmittedAsPreprint,literal,xsd:date,,,,Date when an author submits a preprint of an unpublished resource to a repository.
-,Date Submitted as Postprint,srap:dateSubmittedAsPostprint,literal,xsd:date,,,,Date when an author submits a postprint of an unpublished resource to a repository.
-,Date Updated,srap:dateUpdated,literal,xsd:date,,,,Date(s) when the publication was republished with additional or revised content.
 ,,,,,,,,
 ,Volume,bibo:volume,literal,xsd:string,,,,A volume number of the periodical where this article was published
 ,Issue,bibo:issue,literal,xsd:string,,,,An issue number of the periodical that this article was published in
 ,Start page,bibo:pageStart,literal,xsd:string,,,,Starting page number within a continuous page range.
 ,End page,bibo:pageEnd,literal,xsd:string,,,,Ending page number within a continuous page range.
-,Is Part Of,dct:isPartOf,IRI literal,xsd:anyURI xsd:string,Periodical,,,A related resource in which the described resource is physically or logically included.
-,Has Part,dct:hasPart,IRI literal,xsd:anyURI xsd:string,,,,A related resource that is included either physically or logically in the described resource.
-,Presented At,bibo:presentedAt,IRI literal,xsd:anyURI xsd:string,,,,"Conference, workshop or other scientific event where the scholarly resource was presented."
+,Is Part Of,dct:isPartOf,,,Periodical Book,,,A related resource in which the described resource is physically or logically included.
+,Has Part,dct:hasPart,,,,,,A related resource that is included either physically or logically in the described resource.
+,Presented At,bibo:presentedAt,IRI literal,,,,,"Conference, workshop or other scientific event where the scholarly resource was presented."
 ,Bibliographic Citation,dct:bibliographicCitation,literal,xsd:string,,,,A bibliographic reference for the resource.
+,Relation,dct:relation,IRI literal,,,,,A related resorce.
 ,,,,,,,,
-,Access Rights,dct:accessRights,IRI,xsd:anyURI,,http://purl.org/coar/access_right/,IRIstem,"Access status of the resource, using the COAR Access Rights vocabulary."
-,License,dct:license,IRI literal,xsd:anyURI xsd:string,,,,A legal document giving official permission to do something with the resource.
-,Rights,dct:rights,IRI literal,xsd:anyURI xsd:string,,,,Information about rights held in and over the resource.
-,Rights Holder,dct:rightsHolder,IRI literal,xsd:anyURI xsd:string,,,,A person or organization owning or managing rights over the resource.
+,Abstract,dct:abstract,literal,xsd:string,,,,A summary of the resource.
+,Table of Contents,dct:tableOfContents,literal,xsd:string,,,,A list of subunits of the resource.
+,Description,dct:description,literal,xsd:string,,,,An account of the resource.
+,,,,,,,,
+,Access Rights,dct:accessRights,IRI,,,http://purl.org/coar/access_right/,IRIstem,"Access status of the resource, using the COAR Access Rights vocabulary."
+,License,dct:license,IRI literal,,,,,A legal document giving official permission to do something with the resource.
+,Rights,dct:rights,IRI literal,,,,,Information about rights held in and over the resource.
+,Rights Holder,dct:rightsHolder,IRI literal,,,,,A person or organization owning or managing rights over the resource.
 ,,,,,,,,
 ,Accessibility statement,srap:accessibilityStatement,literal,xsd:string,,,,"Textual information describing the accessibility features of a resource, including technical details."
 ,,,,,,,,
 ,Grant number,srap:grantNumber,literal,xsd:string,,,,"An alpha-numeric string identifying the contract, project or funding grant under which the scholarly resource was created."
 ,,,,,,,,
-,Identifier,dct:identifier,IRI literal,xsd:anyURI xsd:string,,,,"URI, one for each identifier the resource has, provided separately"
+,Identifier,dct:identifier,IRI literal,,,,,"URI, one for each identifier the resource has, provided separately"
 ,ISBN,bibo:isbn,literal,xsd:string,,,,The International Standard Book Number of the resource.
 ,,,,,,,,
-,Related code,srap:relatedCode,IRI,xsd:anyURI,,,,Code (software applications) referenced in the resource.
-,Related dataset,srap:relatedDataset,IRI,xsd:anyURI,,,,Dataset or datasets referenced in the described resource.
+,Related code,srap:relatedCode,IRI,,,,,Code (software applications) referenced in the resource.
+,Related dataset,srap:relatedDataset,IRI,,,,,Dataset or datasets referenced in the described resource.
 ,,,,,,,,
-,Academic supervisor,rdau:P61096,IRI,xsd:anyURI,Person,,,"Relates a resource to an agent who is responsible for overseeing academic activity of any kind that results in a resource, including theses, research, and projects."
-,Dedicatee ,marcrel:dte ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization to whom a resource is dedicated. "
-,Degree committee member,marcrel:dgc ,IRI,xsd:anyURI,Person,,,"A person who is part of a committee that considers the merit of a thesis, dissertation, or other submission by an academic degree candidate."
-,Degree granting institution,marcrel:dgg ,IRI,xsd:anyURI,Organization,,,A organization granting an academic degree.
-,Degree supervisor ,marcrel:dgs ,IRI,xsd:anyURI,Person,,,A person overseeing a higher level academic degree.
-,Dissertant,marcrel:dis ,IRI,xsd:anyURI,Person,,,A person who presents a thesis for a university or higher-level educational degree.
-,Opponent,marcrel:opn ,IRI,xsd:anyURI,Person,,,A person or organization responsible for opposing a thesis or dissertation.
-,Praeses ,marcrel:pra ,IRI,xsd:anyURI,Person,,,"A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation."
-,Respondent,marcrel:rsp ,IRI,xsd:anyURI,Person,,,A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation.
-,Thesis advisor,marcrel:ths ,IRI,xsd:anyURI,Person,,,"A person under whose supervision a degree candidate develops and presents a thesis, memoire, or text of a dissertation."
+,Academic supervisor,rdau:P61096,IRI BNODE,,Person,,,"Relates a resource to an agent who is responsible for overseeing academic activity of any kind that results in a resource, including theses, research, and projects."
+,Dedicatee ,marcrel:dte ,IRI BNODE,,Person Organization,,,"A person, family, or organization to whom a resource is dedicated. "
+,Degree committee member,marcrel:dgc ,IRI BNODE,,Person,,,"A person who is part of a committee that considers the merit of a thesis, dissertation, or other submission by an academic degree candidate."
+,Degree granting institution,marcrel:dgg ,IRI BNODE,,Organization,,,A organization granting an academic degree.
+,Degree supervisor ,marcrel:dgs ,IRI BNODE,,Person,,,A person overseeing a higher level academic degree.
+,Dissertant,marcrel:dis ,IRI BNODE,,Person,,,A person who presents a thesis for a university or higher-level educational degree.
+,Opponent,marcrel:opn ,IRI BNODE,,Person,,,A person or organization responsible for opposing a thesis or dissertation.
+,Praeses ,marcrel:pra ,IRI BNODE,,Person,,,"A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation."
+,Respondent,marcrel:rsp ,IRI BNODE,,Person,,,A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation.
+,Thesis advisor,marcrel:ths ,IRI BNODE,,Person,,,"A person under whose supervision a degree candidate develops and presents a thesis, memoire, or text of a dissertation."
 ,,,,,,,,
-,Abridger ,marcrel:abr ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged"
-,Compiler ,marcrel:com ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc."
-,Editor ,marcrel:edt ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author."
-,Editor of compilation ,marcrel:edc ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler."
-,Funder ,marcrel:fnd ,IRI,xsd:anyURI,Person Organization,,,A person or organization that furnished financial support for the production of the work.
-,Honoree ,marcrel:hnr ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)"
-,Host institution ,marcrel:his ,IRI,xsd:anyURI,Organization,,,"An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource."
-,Organizer ,marcrel:orm ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource."
-,Reviewer ,marcrel:rev ,IRI,xsd:anyURI,Person Organization,,,"A person or organization responsible for the review of a book, motion picture, performance, etc."
-,Reviser ,rdau:P60245,IRI,xsd:anyURI,Person,,,Relates an agent to a resource that includes a contribution by an agent of making changes to the content.
-,Sponsor ,marcrel:spn ,IRI,xsd:anyURI,Person Organization,,,"A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event."
-,Translator ,marcrel:trl ,IRI,xsd:anyURI,Person Organization,,,"A person or organization who renders a text from one language into another, or from an older form of a language into the modern form."
+,Abridger ,marcrel:abr ,IRI BNODE,,Person Organization,,,"A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged"
+,Compiler ,marcrel:com ,IRI BNODE,,Person Organization,,,"A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc."
+,Editor ,marcrel:edt ,IRI BNODE,,Person Organization,,,"A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author."
+,Editor of compilation ,marcrel:edc ,IRI BNODE,,Person Organization,,,"A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler."
+,Funder ,marcrel:fnd ,IRI BNODE,,Person Organization,,,A person or organization that furnished financial support for the production of the work.
+,Honoree ,marcrel:hnr ,IRI BNODE,,Person Organization,,,"A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)"
+,Host institution ,marcrel:his ,IRI BNODE,,Organization,,,"An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource."
+,Organizer ,marcrel:orm ,IRI BNODE,,Person Organization,,,"A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource."
+,Reviewer ,marcrel:rev ,IRI BNODE,,Person Organization,,,"A person or organization responsible for the review of a book, motion picture, performance, etc."
+,Reviser ,rdau:P60245,IRI BNODE,,Person,,,Relates an agent to a resource that includes a contribution by an agent of making changes to the content.
+,Sponsor ,marcrel:spn ,IRI BNODE,,Person Organization,,,"A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event."
+,Translator ,marcrel:trl ,IRI BNODE,,Person Organization,,,"A person or organization who renders a text from one language into another, or from an older form of a language into the modern form."
 ,,,,,,,,
-Periodical,Class,rdf:type,IRI,xsd:anyURI,,bibo:Periodical bibo:Journal,,Class (always bibo:Periodical or one of its subclasses)
+Periodical,Class,rdf:type,IRI,,,bibo:Periodical bibo:Journal,,Class (always bibo:Periodical or one of its subclasses)
 ,Title,dct:title,literal,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
 ,ISSN,bibo:issn,literal,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for the printed version of serial publications."
 ,E-ISSN,bibo:eissn,literal,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for electronic versions of serial publications."
 ,,,,,,,,
-Person,Affiliation,schema:affiliation,,,Organization,,,"An organization to which an agent was affiliated when the resource was created. Recommended practice is to identify the affiliation with a URI. If this is not possible or feasible, a literal value that identifies the affiliated organization may be provided. It is also possible to give both the name and the URI. If a name is given, it should be provided in full and in hierarchical order, starting from the largest organizational unit. NOTE This element should not be used to provide the current (at the time the metadata is created) affiliation of the agent, or all affiliations the agent has had over time."
-,Name,foaf:Name,literal,xsd:string,,,,Name of person
-,Identifier,dct:identifier,IRI literal,xsd:anyURI xsd:string,,,,"Identifier for the person, such as ORCID"
+Book,Class,rdf:type,IRI,,,bibo:Book,,
+,Contributor,dct:contributor,,,Person Organization,,,
+,Publisher,dct:publisher,IRI literal,,,,,
+,Date,dct:date,Literal,xsd:string,,,,
 ,,,,,,,,
-Organization,Identifier,dct:identifier,IRI literal,xsd:anyURI xsd:string,,,,Identifier for the organization
+Person,Class,rdf:type,IRI,,,foaf:Person,,
+,Affiliation,schema:affiliation,,,Organization,,,"An organization to which an agent was affiliated when the resource was created. Recommended practice is to identify the affiliation with a URI. If this is not possible or feasible, a literal value that identifies the affiliated organization may be provided. It is also possible to give both the name and the URI. If a name is given, it should be provided in full and in hierarchical order, starting from the largest organizational unit. NOTE This element should not be used to provide the current (at the time the metadata is created) affiliation of the agent, or all affiliations the agent has had over time."
+,Name,foaf:Name,literal,xsd:string,,,,Name of person
+,Identifier,dct:identifier,IRI literal,,,,,"Identifier for the person, such as ORCID"
+,,,,,,,,
+Organization,Class,rdf:type,IRI,,,foaf:Organization,,
+,Identifier,dct:identifier,IRI literal,,,,,Identifier for the organization
 ,Name,foaf:name,literal,xsd:string,,,,Name of the organization


### PR DESCRIPTION
This PR contains an overhaul of the DCTAP CSV table, along with some related corrections to the main specification.

The main idea is to keep the properties in the DCTAP in (mostly) the same order as in the main specification text.

Changes:
- reorder the DCTAP properties
- add/fix/modify definitions for each property in the `note` column
- make sure each property has a `valueNodeType` and a `valueDatatype`
- many corrections to the specifications of properties
- add `srap:xxxxx` identifiers for those properties that don't yet exist in any well-known schema vocabulary (similar to the main specification text)
- synchronize DCTAP with the main specification text and vice versa

The diff view of the DCTAP file `srap.csv` can be a bit hard to read due to all the reordering. The end result can be seen [here](https://github.com/dcmi/dc-srap/blob/dctap-overhaul/docs/srap.csv).