### PR TITLE
Express relators as roles, not properties

### DIFF
--- a/docs/examples/docthesis-with-opponent-and-series.md
+++ b/docs/examples/docthesis-with-opponent-and-series.md
@@ -17,8 +17,8 @@ Acta Universitatis Lappeenrantaensis 960
 @prefix srap:    <http://example.org/srap/>.  # placeholder namespace for new properties
 @prefix dct:     <http://purl.org/dc/terms/>.
 @prefix bibo:    <http://purl.org/ontology/bibo/> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/>.
 @prefix marcrel: <http://id.loc.gov/vocabulary/relators/>.
-@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 
 # The online thesis we are (mainly) describing
 ex:online_thesis
@@ -37,7 +37,7 @@ ex:online_thesis
   dct:subject "..." ;  # actual subjects omitted for brevity
   dct:title "Faster than real-time simulation of fluid power-driven mechatronic machines"@en ;
   dct:contributor [
-    rdf:value "Ellman, Asko" ;
+    foaf:name "Ellman, Asko" ;
     srap:role marcrel:opn  # official opponent at the doctoral defense, using MARC relator
   ] ;
   dct:type <http://purl.org/coar/resource_type/c_db06> ; # COAR resource type: doctoral thesis
@@ -45,15 +45,15 @@ ex:online_thesis
   dct:contributor "School of Energy Systems"@en ;  # TODO should this be part of the above?
   dct:subject "School of Energy Systems, Mechanical Engineering" ; # TODO is this the correct field for degree program?
   dct:contributor [
-    rdf:value "Ellman, Asko" ;
+    foaf:name "Ellman, Asko" ;
     srap:role marcrel:rev  # reviewer, using MARC relator
   ] ;
   dct:contributor [
-    rdf:value "Pietola, Matti" ;
+    foaf:name "Pietola, Matti" ;
     srap:role marcrel:rev  # reviewer, using MARC relator
   ] ;
   dct:contributor [
-    rdf:value "Handroos, Heikki" ;
+    foaf:name "Handroos, Heikki" ;
     srap:role marcrel:dgs  # degree supervisor, using MARC relator
   ] .
 

--- a/docs/examples/docthesis-with-opponent-and-series.md
+++ b/docs/examples/docthesis-with-opponent-and-series.md
@@ -14,14 +14,17 @@ Acta Universitatis Lappeenrantaensis 960
 
 ```
 @prefix ex:      <http://example.org/>.
+@prefix srap:    <http://example.org/srap/>.  # placeholder namespace for new properties
 @prefix dct:     <http://purl.org/dc/terms/>.
+@prefix bibo:    <http://purl.org/ontology/bibo/> .
 @prefix marcrel: <http://id.loc.gov/vocabulary/relators/>.
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 
 # The online thesis we are (mainly) describing
 ex:online_thesis
   dct:creator "Malysheva, Julia" ;
   dct:issued "2021-06-01" ;
-  dct:identifier <urn:isbn:978-952-335-653-5> ; # electronic ISBN expressed using RFC3187
+  bibo:isbn "978-952-335-653-5" ; # ISBN of electronic version (this one)
   dct:identifier <https://lutpub.lut.fi/handle/10024/162541> ; # repository local URI identifier
   dct:abstract "The level of automation of mechatronic machines, such as..."@en ; # cut for brevity
   dct:extent "79 pages" ; # number of pages, a dct:SizeOrDuration instance
@@ -33,28 +36,38 @@ ex:online_thesis
   dct:rights "Kaikki oikeudet pidätetään."@fi, "All rights reserved."@en ;
   dct:subject "..." ;  # actual subjects omitted for brevity
   dct:title "Faster than real-time simulation of fluid power-driven mechatronic machines"@en ;
-  marcrel:opn "Ellman, Asko" ; # official opponent at the doctoral defense, using MARC relator
+  dct:contributor [
+    rdf:value "Ellman, Asko" ;
+    srap:role marcrel:opn  # official opponent at the doctoral defense, using MARC relator
+  ] ;
   dct:type <http://purl.org/coar/resource_type/c_db06> ; # COAR resource type: doctoral thesis
   dct:contributor "Lappeenrannan-Lahden teknillinen yliopisto LUT"@fi, "Lappeenranta-Lahti University of Technology LUT"@en ;  # TODO should this be a resource? Typed as Organization?
   dct:contributor "School of Energy Systems"@en ;  # TODO should this be part of the above?
   dct:subject "School of Energy Systems, Mechanical Engineering" ; # TODO is this the correct field for degree program?
-  marcrel:rev "Ellman, Asko" ; # reviewer, using MARC relator
-  marcrel:rev "Pietola, Matti" ; # ditto
-  marcrel:dgs "Handroos, Heikki" . # degree supervisor, using MARC relator
+  dct:contributor [
+    rdf:value "Ellman, Asko" ;
+    srap:role marcrel:rev  # reviewer, using MARC relator
+  ] ;
+  dct:contributor [
+    rdf:value "Pietola, Matti" ;
+    srap:role marcrel:rev  # reviewer, using MARC relator
+  ] ;
+  dct:contributor [
+    rdf:value "Handroos, Heikki" ;
+    srap:role marcrel:dgs  # degree supervisor, using MARC relator
+  ] .
 
 # Printed version of the thesis, with a different ISBN
 ex:printed_thesis
-  dct:identifier <urn:isbn:978-952-335-652-8> .  # ISBN of printed version
+  bibo:isbn "978-952-335-652-8" .  # ISBN of printed version
 
 # Series where the thesis was published in (reusable entity)
 ex:series dct:title "Acta Universitatis Lappeenrantaensis" ;
-  dct:identifier <urn:issn:1456-4491> .
+  bibo:issn "1456-4491" .
 ```
 
 ## Visualization
 
 Created from the above Turtle data using [RDF Sketch](https://sketch.zazuko.com/)
 
-![image](https://github.com/dcmi/dc-srap/assets/1132830/9549c6a2-e595-46f4-aa5f-054dee20402e)
-
-
+![image](https://github.com/dcmi/dc-srap/assets/1132830/5c73e9ad-9b39-4c8e-8d16-fcedfbe5756b)

--- a/docs/examples/docthesis-with-opponent-and-series.md
+++ b/docs/examples/docthesis-with-opponent-and-series.md
@@ -70,4 +70,4 @@ ex:series dct:title "Acta Universitatis Lappeenrantaensis" ;
 
 Created from the above Turtle data using [RDF Sketch](https://sketch.zazuko.com/)
 
-![image](https://github.com/dcmi/dc-srap/assets/1132830/5c73e9ad-9b39-4c8e-8d16-fcedfbe5756b)
+![image](https://github.com/dcmi/dc-srap/assets/1132830/66a7ca92-92c7-4e5d-b62d-c5f138191e2c)

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -1,8 +1,8 @@
 shapeID,propertyLabel,propertyID,valueNodeType,valueDatatype,valueShape,valueConstraint,valueConstraintType,note
 ,,,,,,,,
 Scholarly Resource,Type,dct:type,IRI,,,http://purl.org/coar/resource_type/,IRIstem,"Resource type, using the COAR Resorce Types vocabulary."
-,Contributor,dct:contributor,IRI,,Person,,,An entity responsible for making contributions to the resource.
-,Creator,dct:creator,IRI,,Person,,,An entity responsible for making the resource.
+,Contributor,dct:contributor,IRI,,Person Organization,,,An entity responsible for making contributions to the resource.
+,Creator,dct:creator,IRI,,Person Organization,,,An entity responsible for making the resource.
 ,Language,dct:language,literal,xsd:string,,,,A language of the resource.
 ,Publisher,dct:publisher,IRI,,Organization,,,An entity responsible for making the resource available.
 ,Subject,dct:subject,IRI literal,,,,,The topic of the resource; a concept from a controlled vocabulary such as LCSH or MeSH
@@ -45,30 +45,6 @@ Scholarly Resource,Type,dct:type,IRI,,,http://purl.org/coar/resource_type/,IRIst
 ,Related code,srap:relatedCode,IRI,,,,,Code (software applications) referenced in the resource.
 ,Related dataset,srap:relatedDataset,IRI,,,,,Dataset or datasets referenced in the described resource.
 ,,,,,,,,
-,Academic supervisor,rdau:P61096,IRI BNODE,,Person,,,"Relates a resource to an agent who is responsible for overseeing academic activity of any kind that results in a resource, including theses, research, and projects."
-,Dedicatee ,marcrel:dte ,IRI BNODE,,Person Organization,,,"A person, family, or organization to whom a resource is dedicated. "
-,Degree committee member,marcrel:dgc ,IRI BNODE,,Person,,,"A person who is part of a committee that considers the merit of a thesis, dissertation, or other submission by an academic degree candidate."
-,Degree granting institution,marcrel:dgg ,IRI BNODE,,Organization,,,A organization granting an academic degree.
-,Degree supervisor ,marcrel:dgs ,IRI BNODE,,Person,,,A person overseeing a higher level academic degree.
-,Dissertant,marcrel:dis ,IRI BNODE,,Person,,,A person who presents a thesis for a university or higher-level educational degree.
-,Opponent,marcrel:opn ,IRI BNODE,,Person,,,A person or organization responsible for opposing a thesis or dissertation.
-,Praeses ,marcrel:pra ,IRI BNODE,,Person,,,"A person who is the faculty moderator of an academic disputation, normally proposing a thesis and participating in the ensuing disputation."
-,Respondent,marcrel:rsp ,IRI BNODE,,Person,,,A person or organization who makes an answer to the courts pursuant to an application for redress (usually in an equity proceeding) or a candidate for a degree who defends or opposes a thesis provided by the praeses in an academic disputation.
-,Thesis advisor,marcrel:ths ,IRI BNODE,,Person,,,"A person under whose supervision a degree candidate develops and presents a thesis, memoire, or text of a dissertation."
-,,,,,,,,
-,Abridger ,marcrel:abr ,IRI BNODE,,Person Organization,,,"A person, family, or organization contributing to a resource by shortening or condensing the original work but leaving the nature and content of the original work substantially unchanged"
-,Compiler ,marcrel:com ,IRI BNODE,,Person Organization,,,"A person, family, or organization responsible for creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc."
-,Editor ,marcrel:edt ,IRI BNODE,,Person Organization,,,"A person, family, or organization contributing to a resource by revising or elucidating the content, e.g., adding an introduction, notes, or other critical matter. An editor may also prepare a resource for production, publication, or distribution. For major revisions, adaptations, etc., that substantially change the nature and content of the original work, resulting in a new work, see author."
-,Editor of compilation ,marcrel:edc ,IRI BNODE,,Person Organization,,,"A person, family, or organization contributing to a collective or aggregate work by selecting and putting together works, or parts of works, by one or more creators. For compilations of data, information, etc., that result in new works, see compiler."
-,Funder ,marcrel:fnd ,IRI BNODE,,Person Organization,,,A person or organization that furnished financial support for the production of the work.
-,Honoree ,marcrel:hnr ,IRI BNODE,,Person Organization,,,"A person, family, or organization honored by a work or item (e.g., the honoree of a festschrift, a person to whom a copy is presented)"
-,Host institution ,marcrel:his ,IRI BNODE,,Organization,,,"An organization hosting the event, exhibit, conference, etc., which gave rise to a resource, but having little or no responsibility for the content of the resource."
-,Organizer ,marcrel:orm ,IRI BNODE,,Person Organization,,,"A person, family, or organization organizing the exhibit, event, conference, etc., which gave rise to a resource."
-,Reviewer ,marcrel:rev ,IRI BNODE,,Person Organization,,,"A person or organization responsible for the review of a book, motion picture, performance, etc."
-,Reviser ,rdau:P60245,IRI BNODE,,Person,,,Relates an agent to a resource that includes a contribution by an agent of making changes to the content.
-,Sponsor ,marcrel:spn ,IRI BNODE,,Person Organization,,,"A person, family, or organization sponsoring some aspect of a resource, e.g., funding research, sponsoring an event."
-,Translator ,marcrel:trl ,IRI BNODE,,Person Organization,,,"A person or organization who renders a text from one language into another, or from an older form of a language into the modern form."
-,,,,,,,,
 Periodical,Class,rdf:type,IRI,,,bibo:Periodical bibo:Journal,,Class (always bibo:Periodical or one of its subclasses)
 ,Title,dct:title,literal,xsd:string,,,,A name given to the resource. Titles in different languages provided separately
 ,ISSN,bibo:issn,literal,xsd:string,,,,"The International Standard Serial Number, ISSN, an identifier for the printed version of serial publications."
@@ -80,10 +56,12 @@ Book,Class,rdf:type,IRI,,,bibo:Book,,
 ,Date,dct:date,Literal,xsd:string,,,,
 ,,,,,,,,
 Person,Class,rdf:type,IRI,,,foaf:Person,,
+,Role,srap:role,IRI,,,http://id.loc.gov/vocabulary/relators/,IRIstem,"The role of the person in the context of the publication, expressed using MARC relators."
 ,Affiliation,schema:affiliation,,,Organization,,,An organization to which an agent was affiliated when the resource was created.
 ,Name,foaf:Name,literal,xsd:string,,,,Name of person
 ,Identifier,dct:identifier,IRI literal,,,,,"Identifier for the person, such as ORCID"
 ,,,,,,,,
 Organization,Class,rdf:type,IRI,,,foaf:Organization,,
+,Role,srap:role,IRI,,,http://id.loc.gov/vocabulary/relators/,IRIstem,"The role of the organization in the context of the publication, expressed using MARC relators."
 ,Identifier,dct:identifier,IRI literal,,,,,Identifier for the organization
 ,Name,foaf:name,literal,xsd:string,,,,Name of the organization


### PR DESCRIPTION
This PR changes the way contributor roles are expressed: instead of using MARC relators as RDF properties, the dct:contributor (or creator) value is now a blank node that can have a srap:role attached, similar to how MARC and BIBFRAME express contributor roles.

I didn't change the main spec because I know that @kcoyle is working on restructuring it at the same time. So this PR only changes the TAP and the docthesis-with-opponent-and-series.md example.