### PR TITLE
Add bibo:number property

### DIFF
--- a/docs/srap-profile.md
+++ b/docs/srap-profile.md
@@ -217,7 +217,7 @@ This property SHOULD be used to provide the URL where the electronic resource (e
 ### Enumeration
 
 The scholarly work shape includes properties that define and locate the work in the context of monograph or periodical in which the focus work is contained.  These are:
-> `bibo:volume`, `bibo:issue`, `bibo:pageStart`, `bibo:pageEnd` 
+> `bibo:volume`, `bibo:issue`, `bibo:number`, `bibo:pageStart`, `bibo:pageEnd`
 
 These properties SHOULD be used to locate the scholarly work within a containing publication, which is described in a Periodical shape or a Book shape. They are assumed to be literals and SHOULD include just the number itself. 
 
@@ -228,6 +228,10 @@ If available, the designated volume in which the scholarly work is published. Th
 **bibo:issue**
 
 The periodical issue in which the scholarly work was published.
+
+**bibo:number**
+
+A generic item or document number, for example the number of a publication within a series.
 
 **bibo:pageStart**
 

--- a/docs/srap.csv
+++ b/docs/srap.csv
@@ -37,6 +37,7 @@ SRAPResource,Class,rdf:type,IRI,,,srap:SRAPResource,,The class will always be sr
 ,,,,,,,,
 ,Volume,bibo:volume,literal,xsd:string,,,,A volume number of the periodical where this article was published
 ,Issue,bibo:issue,literal,xsd:string,,,,An issue number of the periodical that this article was published in
+,Number,bibo:number,literal,xsd:string,,,,An item or document number
 ,Start page,bibo:pageStart,literal,xsd:string,,,,Starting page number within a continuous page range.
 ,End page,bibo:pageEnd,literal,xsd:string,,,,Ending page number within a continuous page range.
 ,,,,,,,,


### PR DESCRIPTION
This PR adds the `bibo:number` element to the main profile document and the TAP.

The reason for this is that the [detailed doctoral thesis example](https://github.com/dcmi/dc-srap/blob/main/docs/examples/thesis-detailed.md) uses `bibo:number` to represent "number in series", in this case "Acta Universitatis Lappeenrantaensis 960", where 960 is the number. This kind of numbering is a common convention in thesis series like this one, at least in Finnish universities.

BIBO already includes the literal value property [bibo:number](https://dcmi.github.io/bibo/#:number), defined as "A generic item or document number. Not to be confused with issue number."  I think it's the best available BIBO property to represent this kind of numbering - it is not the same as volume or issue numbers used in journal enumeration, which have their own BIBO properties and are already included in SRAP.

Fixes #36